### PR TITLE
fix: Make parentheses really useless

### DIFF
--- a/docs/fundamentals/comments.md
+++ b/docs/fundamentals/comments.md
@@ -56,5 +56,5 @@ The `@ignore` comment can be used to ignore linting errors.
 
 ```
 // @ignore(L0515) - useless parentheses
-$foo = (1 + 2) * 3;
+$foo = 1 + (2 * 3);
 ```


### PR DESCRIPTION
I was just skimming through the documentation, and think there is a tiny typo. As the parentheses in the example would be required (at least in my understanding).